### PR TITLE
Remove calls to virtual methods in `StatusCallBack` constructor.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/model/StatusCallback.h
+++ b/IfcPlusPlus/src/ifcpp/model/StatusCallback.h
@@ -66,11 +66,7 @@ public:
 		std::wstring m_progress_text;		// A text that describes the current actions. It can be used for example to set a text on the progress bar.
 	};
 
-	StatusCallback()
-	{
-		unsetMessageCallBack();
-		unsetCancelCheck();
-	}
+	StatusCallback() = default;
 	virtual ~StatusCallback()= default;
 
 	//\brief error callback mechanism to show messages in gui
@@ -221,16 +217,16 @@ public:
 
 protected:
 	//\brief Pointer to the object on which the message callback function is called.
-	void* m_obj_call_on_message;
+	void* m_obj_call_on_message = nullptr;
 
 	//\brief Pointer to the object on which the cancel check function is called.
-	void* m_obj_call_check_cancel;
+	void* m_obj_call_check_cancel = nullptr;
 
 	//\brief Pointer to the callback function for messages.
-	void (*m_func_call_on_message)(void*, shared_ptr<Message> t);
+	void (*m_func_call_on_message)(void*, shared_ptr<Message> t) = nullptr;
 
 	//\brief Pointer to the predicate that determines whether an operation should be canceled.
-	bool  (*m_func_check_cancel)(void*);
+	bool  (*m_func_check_cancel)(void*) = nullptr;
 
 	StatusCallback* m_redirect_target = nullptr;
 


### PR DESCRIPTION
Clang-tidy (clang-analyzer-optin.cplusplus.VirtualCall) generates warnings for `StatusCallback.h`, which is a public header. The warning is due to the use of virtual methods in the constructor.

```
/usr/local/include/ifcpp/model/StatusCallback.h:71:3: error: Call to virtual function during construction [clang-analyzer-optin.cplusplus.VirtualCall,-warnings-as-errors]
                unsetMessageCallBack();
                ^

/usr/local/include/ifcpp/model/StatusCallback.h:72:3: error: Call to virtual function during construction [clang-analyzer-optin.cplusplus.VirtualCall,-warnings-as-errors]
                unsetCancelCheck();
                ^
```

The suggested solution uses the default constructor and sets `m_obj_call_on_message`, `m_obj_call_check_cancel`, `m_func_call_on_message` and `m_func_check_cancel` to `nullptr` as default value.

Another solution would be to call the methods of `StatusCallback` explicitly:

```cpp
StatusCallback()
{
    StatusCallback::unsetMessageCallBack();
    StatusCallback::unsetCancelCheck();
}
```

Some guidelines on the topic can be found here [C.82](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rc-ctor-virtual).